### PR TITLE
Integrate PHP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@
 
 ### Публичные эндпоинты
 - `GET /api/products` - Получить товары с фильтрацией
+- `GET /api/php/products` - Получить товары из PHP сервера
+- `GET /api/php/products/{id}` - Получить товар из PHP по ID
+- `GET /api/php/categories` - Список категорий из PHP сервера
 - `GET /api/categories` - Получить все категории
 - `GET /api/categories/stats` - Статистика по категориям
 - `GET /api/products/{id}` - Получить товар по ID
@@ -122,6 +125,7 @@ npm start
 ```
 MONGO_URL=mongodb://localhost:27017
 DB_NAME=ecommerce_db
+PHP_BACKEND_URL=http://localhost:8001
 ```
 
 **Frontend (.env):**

--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,3 @@
 MONGO_URL="mongodb://localhost:27017"
 DB_NAME="test_database"
+PHP_BACKEND_URL="http://localhost:8001"


### PR DESCRIPTION
## Summary
- integrate PHP backend by adding new HTTPX routes in `backend/server.py`
- document `PHP_BACKEND_URL` and new PHP endpoints in README
- include `PHP_BACKEND_URL` in backend `.env`

## Testing
- `python -m py_compile backend/server.py`
- `php -l backend_php/server.php`
- `pytest -q` *(fails: async def function requires plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6883d1bcf4d0832ca49ab3f7988f94b2